### PR TITLE
Add bindings for cs_reg_name and cs_insn_name

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,19 +12,6 @@ fn main() {
                 for i in insns.iter() {
                     println!("{:?}", i);
                 }
-
-                let reg_id = 1;
-                match cs.reg_name(reg_id) {
-                    Some(reg_name) => println!("reg name: {}", reg_name),
-                    None => println!("invalid reg_id : {}", reg_id),
-                }
-
-                let insn_id = 1;
-                match cs.insn_name(insn_id) {
-                    Some(insn_name) => println!("insn name: {}", insn_name),
-                    None => println!("invalid insn_id : {}", reg_id),
-                }
-
             }
         },
         None => {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,6 +12,19 @@ fn main() {
                 for i in insns.iter() {
                     println!("{:?}", i);
                 }
+
+                let reg_id = 1;
+                match cs.reg_name(reg_id) {
+                    Some(reg_name) => println!("reg name: {}", reg_name),
+                    None => println!("invalid reg_id : {}", reg_id),
+                }
+
+                let insn_id = 1;
+                match cs.insn_name(insn_id) {
+                    Some(insn_name) => println!("insn name: {}", insn_name),
+                    None => println!("invalid insn_id : {}", reg_id),
+                }
+
             }
         },
         None => {

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -1,8 +1,8 @@
 use libc;
 use std::ptr;
+use std::ffi::CStr;
 use constants::*;
-use ffi::{cs_close, cs_open, cs_disasm};
-
+use ffi::{cs_close, cs_open, cs_disasm, cs_reg_name, cs_insn_name};
 use instruction::{Insn, Instructions};
 
 pub struct Capstone {
@@ -35,6 +35,32 @@ impl Capstone {
         }
 
         Some(Instructions::from_raw_parts(ptr, insn_count as isize))
+    }
+
+    pub fn reg_name(&self, reg_id: u64) -> Option<String> {
+        let reg_name = unsafe {
+            let _reg_name = cs_reg_name(self.csh, reg_id as libc::size_t);
+            if _reg_name == ptr::null() {
+                return None;
+            }
+
+            CStr::from_ptr(_reg_name).to_string_lossy().into_owned()
+        };
+
+        Some(reg_name)
+    }
+
+    pub fn insn_name(&self, reg_id: u64) -> Option<String> {
+        let reg_name = unsafe {
+            let _reg_name = cs_insn_name(self.csh, reg_id as libc::size_t);
+            if _reg_name == ptr::null() {
+                return None;
+            }
+
+            CStr::from_ptr(_reg_name).to_string_lossy().into_owned()
+        };
+
+        Some(reg_name)
     }
 }
 

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -1,9 +1,9 @@
 use libc;
 use std::ptr;
 use constants::*;
-use ffi::{cs_close,cs_open,cs_disasm};
+use ffi::{cs_close, cs_open, cs_disasm};
 
-use instruction::{Insn,Instructions};
+use instruction::{Insn, Instructions};
 
 pub struct Capstone {
     csh: libc::size_t, // Opaque handle to cs_engine
@@ -13,9 +13,7 @@ impl Capstone {
     pub fn new(arch: CsArch, mode: CsMode) -> Option<Capstone> {
         let mut handle: libc::size_t = 0;
         if let CsErr::CS_ERR_OK = unsafe { cs_open(arch, mode, &mut handle) } {
-            Some(Capstone {
-                csh: handle
-            })
+            Some(Capstone { csh: handle })
         } else {
             None
         }
@@ -23,11 +21,17 @@ impl Capstone {
 
     pub fn disasm(&self, code: &[u8], addr: u64, count: isize) -> Option<Instructions> {
         let mut ptr: *const Insn = ptr::null();
-        let insn_count = unsafe { cs_disasm(self.csh, code.as_ptr(), code.len() as libc::size_t,
-                                            addr, count as libc::size_t, &mut ptr) };
+        let insn_count = unsafe {
+            cs_disasm(self.csh,
+                      code.as_ptr(),
+                      code.len() as libc::size_t,
+                      addr,
+                      count as libc::size_t,
+                      &mut ptr)
+        };
         if insn_count == 0 {
             // TODO  On failure, call cs_errno() for error code.
-            return None
+            return None;
         }
 
         Some(Instructions::from_raw_parts(ptr, insn_count as isize))

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,51 +1,51 @@
 #[repr(C)]
 pub enum CsArch {
-    ARCH_ARM = 0,    // ARM architecture (including Thumb, Thumb-2)
-    ARCH_ARM64,      // ARM-64, also called AArch64
-    ARCH_MIPS,       // Mips architecture
-    ARCH_X86,        // X86 architecture (including x86 & x86-64)
-    ARCH_PPC,        // PowerPC architecture
-    ARCH_SPARC,      // Sparc architecture
-    ARCH_SYSZ,       // SystemZ architecture
-    ARCH_XCORE,      // XCore architecture
+    ARCH_ARM = 0, // ARM architecture (including Thumb, Thumb-2)
+    ARCH_ARM64, // ARM-64, also called AArch64
+    ARCH_MIPS, // Mips architecture
+    ARCH_X86, // X86 architecture (including x86 & x86-64)
+    ARCH_PPC, // PowerPC architecture
+    ARCH_SPARC, // Sparc architecture
+    ARCH_SYSZ, // SystemZ architecture
+    ARCH_XCORE, // XCore architecture
     ARCH_MAX,
     ARCH_ALL = 0xFFFF, // All architectures - for cs_support()
 }
 
 #[repr(C)]
 pub enum CsMode {
-    MODE_LITTLE_ENDIAN = 0,  // little-endian mode (default mode)
+    MODE_LITTLE_ENDIAN = 0, // little-endian mode (default mode)
     // MODE_ARM = 0,    // 32-bit ARM
-    MODE_16 = 1 << 1,    // 16-bit mode (X86)
-    MODE_32 = 1 << 2,    // 32-bit mode (X86)
-    MODE_64 = 1 << 3,    // 64-bit mode (X86, PPC)
+    MODE_16 = 1 << 1, // 16-bit mode (X86)
+    MODE_32 = 1 << 2, // 32-bit mode (X86)
+    MODE_64 = 1 << 3, // 64-bit mode (X86, PPC)
     MODE_THUMB = 1 << 4, // ARM's Thumb mode, including Thumb-2
-    MODE_MCLASS = 1 << 5,    // ARM's Cortex-M series
-    MODE_V8 = 1 << 6,    // ARMv8 A32 encodings for ARM
+    MODE_MCLASS = 1 << 5, // ARM's Cortex-M series
+    MODE_V8 = 1 << 6, // ARMv8 A32 encodings for ARM
     // MODE_MICRO = 1 << 4, // MicroMips mode (MIPS)
     // MODE_MIPS3 = 1 << 5, // Mips III ISA
     // MODE_MIPS32R6 = 1 << 6, // Mips32r6 ISA
     // MODE_MIPSGP64 = 1 << 7, // General Purpose Registers are 64-bit wide (MIPS)
     // MODE_V9 = 1 << 4, // SparcV9 mode (Sparc)
-    MODE_BIG_ENDIAN = 1 << 31,   // big-endian mode
-    // MODE_MIPS32 = CsMode::MODE_32,    // Mips32 ISA (Mips)
-    // MODE_MIPS64 = CsMode::MODE_64,    // Mips64 ISA (Mips)
+    MODE_BIG_ENDIAN = 1 << 31, /* big-endian mode
+                                * MODE_MIPS32 = CsMode::MODE_32,    // Mips32 ISA (Mips)
+                                * MODE_MIPS64 = CsMode::MODE_64,    // Mips64 ISA (Mips) */
 }
 
 #[repr(C)]
 pub enum CsErr {
-    CS_ERR_OK = 0,   // No error: everything was fine
-    CS_ERR_MEM,      // Out-Of-Memory error: cs_open(), cs_disasm(), cs_disasm_iter()
-    CS_ERR_ARCH,     // Unsupported architecture: cs_open()
-    CS_ERR_HANDLE,   // Invalid handle: cs_op_count(), cs_op_index()
-    CS_ERR_CSH,      // Invalid csh argument: cs_close(), cs_errno(), cs_option()
-    CS_ERR_MODE,     // Invalid/unsupported mode: cs_open()
-    CS_ERR_OPTION,   // Invalid/unsupported option: cs_option()
-    CS_ERR_DETAIL,   // Information is unavailable because detail option is OFF
+    CS_ERR_OK = 0, // No error: everything was fine
+    CS_ERR_MEM, // Out-Of-Memory error: cs_open(), cs_disasm(), cs_disasm_iter()
+    CS_ERR_ARCH, // Unsupported architecture: cs_open()
+    CS_ERR_HANDLE, // Invalid handle: cs_op_count(), cs_op_index()
+    CS_ERR_CSH, // Invalid csh argument: cs_close(), cs_errno(), cs_option()
+    CS_ERR_MODE, // Invalid/unsupported mode: cs_open()
+    CS_ERR_OPTION, // Invalid/unsupported option: cs_option()
+    CS_ERR_DETAIL, // Information is unavailable because detail option is OFF
     CS_ERR_MEMSETUP, // Dynamic memory management uninitialized (see CS_OPT_MEM)
-    CS_ERR_VERSION,  // Unsupported version (bindings)
-    CS_ERR_DIET,     // Access irrelevant data in "diet" engine
+    CS_ERR_VERSION, // Unsupported version (bindings)
+    CS_ERR_DIET, // Access irrelevant data in "diet" engine
     CS_ERR_SKIPDATA, // Access irrelevant data for "data" instruction in SKIPDATA mode
-    CS_ERR_X86_ATT,  // X86 AT&T syntax is unsupported (opt-out at compile time)
+    CS_ERR_X86_ATT, // X86 AT&T syntax is unsupported (opt-out at compile time)
     CS_ERR_X86_INTEL, // X86 Intel syntax is unsupported (opt-out at compile time)
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,10 +8,19 @@ use csh;
 extern "C" {
     pub fn cs_open(arch: CsArch, mode: CsMode, handle: *mut csh) -> CsErr;
     pub fn cs_close(handle: *mut csh) -> CsErr;
-    pub fn cs_disasm(handle: csh, code: *const u8, code_size: libc::size_t,
-                     address: u64, count: libc::size_t, insn: &mut *const Insn) -> libc::size_t;
-    pub fn cs_disasm_ex(handle: csh, code: *const u8, code_size: libc::size_t,
-                        address: u64, count: libc::size_t, insn: &mut *const Insn) -> libc::size_t;
+    pub fn cs_disasm(handle: csh,
+                     code: *const u8,
+                     code_size: libc::size_t,
+                     address: u64,
+                     count: libc::size_t,
+                     insn: &mut *const Insn)
+                     -> libc::size_t;
+    pub fn cs_disasm_ex(handle: csh,
+                        code: *const u8,
+                        code_size: libc::size_t,
+                        address: u64,
+                        count: libc::size_t,
+                        insn: &mut *const Insn)
+                        -> libc::size_t;
     pub fn cs_free(insn: *const Insn, count: libc::size_t);
 }
-

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -23,4 +23,6 @@ extern "C" {
                         insn: &mut *const Insn)
                         -> libc::size_t;
     pub fn cs_free(insn: *const Insn, count: libc::size_t);
+    pub fn cs_reg_name(handle: csh, reg_id: libc::size_t) -> *const libc::c_char;
+    pub fn cs_insn_name(handle: csh, insn_id: libc::size_t) -> *const libc::c_char;
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -27,13 +27,18 @@ impl Instructions {
     }
 
     pub fn iter(&self) -> InstructionIterator {
-        InstructionIterator { insns: &self, cur: 0 }
+        InstructionIterator {
+            insns: &self,
+            cur: 0,
+        }
     }
 }
 
 impl Drop for Instructions {
     fn drop(&mut self) {
-        unsafe { cs_free(self.ptr, self.len as libc::size_t); }
+        unsafe {
+            cs_free(self.ptr, self.len as libc::size_t);
+        }
     }
 }
 
@@ -82,10 +87,10 @@ impl Insn {
 impl Debug for Insn {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Insn")
-            .field("address", &self.address)
-            .field("size", &self.size)
-            .field("mnemonic", &self.mnemonic())
-            .field("op_str", &self.op_str())
-            .finish()
+           .field("address", &self.address)
+           .field("size", &self.size)
+           .field("mnemonic", &self.mnemonic())
+           .field("op_str", &self.op_str())
+           .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,24 +27,23 @@ mod test {
 
     #[test]
     fn test_x86_simple() {
-    match capstone::Capstone::new(constants::CsArch::ARCH_X86,
-                                  constants::CsMode::MODE_64) {
-        Some(cs) => {
-            if let Some(insns) = cs.disasm(CODE, 0x1000, 0) {
-                assert_eq!(insns.len(), 2);
-                let is: Vec<_> = insns.iter().collect();
-                assert_eq!(is[0].mnemonic().unwrap(), "push");
-                assert_eq!(is[1].mnemonic().unwrap(), "mov");
+        match capstone::Capstone::new(constants::CsArch::ARCH_X86, constants::CsMode::MODE_64) {
+            Some(cs) => {
+                if let Some(insns) = cs.disasm(CODE, 0x1000, 0) {
+                    assert_eq!(insns.len(), 2);
+                    let is: Vec<_> = insns.iter().collect();
+                    assert_eq!(is[0].mnemonic().unwrap(), "push");
+                    assert_eq!(is[1].mnemonic().unwrap(), "mov");
 
-                assert_eq!(is[0].address, 0x1000);
-                assert_eq!(is[1].address, 0x1001);
-            } else {
-                assert!(false, "Couldn't disasm instructions")
+                    assert_eq!(is[0].address, 0x1000);
+                    assert_eq!(is[1].address, 0x1001);
+                } else {
+                    assert!(false, "Couldn't disasm instructions")
+                }
             }
-        },
-        None => {
-            assert!(false, "Couldn't create a cs engine");
+            None => {
+                assert!(false, "Couldn't create a cs engine");
+            }
         }
     }
-}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,18 @@ mod test {
                 } else {
                     assert!(false, "Couldn't disasm instructions")
                 }
+
+                let reg_id = 1;
+                match cs.reg_name(reg_id) {
+                    Some(reg_name) => assert_eq!(reg_name, "ah"),
+                    None => assert!(false, "Couldn't get register name"),
+                }
+
+                let insn_id = 1;
+                match cs.insn_name(insn_id) {
+                    Some(insn_name) => assert_eq!(insn_name, "aaa"),
+                    None => assert!(false, "Couldn't get instruction name"),
+                }
             }
             None => {
                 assert!(false, "Couldn't create a cs engine");


### PR DESCRIPTION
This pull request adds cs_reg_name and cs_insn_name. 

I also reformatted the code with `cargo fmt` (it uses rustfmt), if you don't like the new formatting I can make a PR without it.