### PR TITLE
Expose some of the cs_detail interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ repository = "https://github.com/richo/capstone-rs"
 
 [dependencies]
 
+enum_primitive = "0.1.1"
 libc = "*"
+num = "0.1.37"
 
 # Not actually a dependency, but this makes the more complicated examples work
 [dev-dependencies]

--- a/THIRD_PARTY.txt
+++ b/THIRD_PARTY.txt
@@ -1,0 +1,33 @@
+capstone-rs contains code from Capstone, whose license follows:
+
+This is the software license for Capstone disassembly framework.
+Capstone has been designed & implemented by Nguyen Anh Quynh <aquynh@gmail.com>
+
+See http://www.capstone-engine.org for further information.
+
+Copyright (c) 2013, COSEINC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the developer(s) nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -158,7 +158,7 @@ impl Capstone {
 
     /// Returns the current error that could arise from enabling `CS_ERR_SKIPDATA`.
     fn get_skipdata_error(insn: &Insn) -> Option<CsErr> {
-        if insn.get_id() == 0 {
+        if insn.id() == 0 {
             Some(CsErr::CS_ERR_SKIPDATA)
         } else {
             None
@@ -205,8 +205,18 @@ impl Capstone {
             return Err(e);
         }
 
-        let group_ids = unsafe { (*insn.detail).get_group_ids() };
+        let group_ids = unsafe { (*insn.detail()).groups_ids() };
         Ok(group_ids)
+    }
+
+    /// Returns groups to which an instruction belongs.
+    pub fn get_insn_groups(&self, insn: &Insn) -> CsResult<Vec<CsGroupType>> {
+        if let Err(e) = self.is_insn_group_valid(insn) {
+            return Err(e);
+        }
+
+        let groups = unsafe { (*insn.detail()).groups() };
+        Ok(groups)
     }
 
     /// Returns whether read or write registers may be queried.
@@ -241,7 +251,7 @@ impl Capstone {
             return Err(e);
         }
 
-        let reg_read_ids = unsafe { (*insn.detail).get_regs_read_ids() };
+        let reg_read_ids = unsafe { (*insn.detail()).regs_read_ids() };
         Ok(reg_read_ids)
     }
 
@@ -264,7 +274,7 @@ impl Capstone {
             return Err(e);
         }
 
-        let reg_write_ids = unsafe { (*insn.detail).get_regs_write_ids() };
+        let reg_write_ids = unsafe { (*insn.detail()).regs_write_ids() };
         Ok(reg_write_ids)
     }
 }

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -299,8 +299,7 @@ impl Capstone {
 
     /// Returns whether the capstone library was compiled in diet mode.
     pub fn is_diet() -> bool {
-        const CS_SUPPORT_DIET: libc::c_int = ((CsArch::ARCH_ALL as libc::c_int) + 1);
-        unsafe { ffi::cs_support(CS_SUPPORT_DIET as libc::c_int) }
+        unsafe { ffi::cs_support(::constants::CS_SUPPORT_DIET as libc::c_int) }
     }
 }
 

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -94,7 +94,7 @@ impl Drop for Capstone {
 }
 
 /// Return tuple (major, minor) indicating the version of the capstone C library
-pub fn capstone_lib_version() -> (u32, u32) {
+pub fn lib_version() -> (u32, u32) {
     let mut major: libc::c_int = 0;
     let mut minor: libc::c_int = 0;
     let major_ptr: *mut libc::c_int = &mut major;

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -64,14 +64,14 @@ impl Capstone {
                            &mut ptr)
         };
         if insn_count == 0 {
-            return self.get_error_result();
+            return self.error_result();
         }
 
         Ok(unsafe { Instructions::from_raw_parts(ptr, insn_count as isize) })
     }
 
     /// Returns an `CsResult::Err` based on current errno.
-    fn get_error_result<T>(&self) -> CsResult<T> {
+    fn error_result<T>(&self) -> CsResult<T> {
         Err(unsafe { ffi::cs_errno(self.csh) })
     }
 
@@ -146,7 +146,7 @@ impl Capstone {
     }
 
     /// Returns the current error from not enabling `CS_OPT_DETAIL`.
-    fn get_detail_required_error(&self) -> Option<CsErr> {
+    fn detail_required_error(&self) -> Option<CsErr> {
         if *self.cs_option_state
                 .get(&CsOptType::CS_OPT_DETAIL)
                 .unwrap() == CsOptValueBool::CS_OPT_OFF as libc::size_t {
@@ -157,7 +157,7 @@ impl Capstone {
     }
 
     /// Returns the current error that could arise from enabling `CS_ERR_SKIPDATA`.
-    fn get_skipdata_error(insn: &Insn) -> Option<CsErr> {
+    fn skipdata_error(insn: &Insn) -> Option<CsErr> {
         if insn.id() == 0 {
             Some(CsErr::CS_ERR_SKIPDATA)
         } else {
@@ -166,7 +166,7 @@ impl Capstone {
     }
 
     /// Returns the error that could arise from capstone being compiled in diet mode.
-    fn get_is_diet_error() -> Option<CsErr> {
+    fn is_diet_error() -> Option<CsErr> {
         if is_diet() {
             Some(CsErr::CS_ERR_DIET)
         } else {
@@ -178,11 +178,11 @@ impl Capstone {
     ///
     /// Returns `Ok` if there is no error, or `Err` otherwise.
     fn is_insn_group_valid(&self, insn: &Insn) -> CsResult<()> {
-        if let Some(err) = self.get_detail_required_error() {
+        if let Some(err) = self.detail_required_error() {
             Err(err)
-        } else if let Some(err) = Self::get_skipdata_error(insn) {
+        } else if let Some(err) = Self::skipdata_error(insn) {
             Err(err)
-        } else if let Some(err) = Self::get_is_diet_error() {
+        } else if let Some(err) = Self::is_diet_error() {
             Err(err)
         } else {
             Ok(())
@@ -200,7 +200,7 @@ impl Capstone {
 
 
     /// Returns groups ids to which an instruction belongs.
-    pub fn get_insn_group_ids(&self, insn: &Insn) -> CsResult<&[u8]> {
+    pub fn insn_group_ids(&self, insn: &Insn) -> CsResult<&[u8]> {
         if let Err(e) = self.is_insn_group_valid(insn) {
             return Err(e);
         }
@@ -210,7 +210,7 @@ impl Capstone {
     }
 
     /// Returns groups to which an instruction belongs.
-    pub fn get_insn_groups(&self, insn: &Insn) -> CsResult<Vec<CsGroupType>> {
+    pub fn insn_groups(&self, insn: &Insn) -> CsResult<Vec<CsGroupType>> {
         if let Err(e) = self.is_insn_group_valid(insn) {
             return Err(e);
         }
@@ -223,9 +223,9 @@ impl Capstone {
     ///
     /// Returns `Ok` if there is no error, or `Err` otherwise.
     fn is_reg_read_write_valid(&self, insn: &Insn) -> CsResult<()> {
-        if let Some(err) = Self::get_skipdata_error(insn) {
+        if let Some(err) = Self::skipdata_error(insn) {
             Err(err)
-        } else if let Some(err) = Self::get_is_diet_error() {
+        } else if let Some(err) = Self::is_diet_error() {
             Err(err)
         } else {
             Ok(())

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -31,16 +31,19 @@ impl Capstone {
 
         if CsErr::CS_ERR_OK == err {
             let mut opt_state: HashMap<CsOptType, libc::size_t> = HashMap::new();
-            opt_state.insert(CsOptType::CS_OPT_SYNTAX, CsOptValueSyntax::CS_OPT_SYNTAX_DEFAULT as libc::size_t);
-            opt_state.insert(CsOptType::CS_OPT_DETAIL, CsOptValueBool::CS_OPT_OFF as libc::size_t);
+            opt_state.insert(CsOptType::CS_OPT_SYNTAX,
+                             CsOptValueSyntax::CS_OPT_SYNTAX_DEFAULT as libc::size_t);
+            opt_state.insert(CsOptType::CS_OPT_DETAIL,
+                             CsOptValueBool::CS_OPT_OFF as libc::size_t);
             opt_state.insert(CsOptType::CS_OPT_MODE, mode as libc::size_t);
             opt_state.insert(CsOptType::CS_OPT_MEM, 0);
-            opt_state.insert(CsOptType::CS_OPT_SKIPDATA, CsOptValueBool::CS_OPT_OFF as libc::size_t);
+            opt_state.insert(CsOptType::CS_OPT_SKIPDATA,
+                             CsOptValueBool::CS_OPT_OFF as libc::size_t);
 
             Ok(Capstone {
-                csh: handle,
-                cs_option_state: opt_state,
-            })
+                   csh: handle,
+                   cs_option_state: opt_state,
+               })
         } else {
             Err(err)
         }
@@ -53,11 +56,11 @@ impl Capstone {
         let mut ptr: *const Insn = ptr::null();
         let insn_count = unsafe {
             ffi::cs_disasm(self.csh,
-                      code.as_ptr(),
-                      code.len() as libc::size_t,
-                      addr,
-                      count as libc::size_t,
-                      &mut ptr)
+                           code.as_ptr(),
+                           code.len() as libc::size_t,
+                           addr,
+                           count as libc::size_t,
+                           &mut ptr)
         };
         if insn_count == 0 {
             return self.get_error_result();
@@ -67,16 +70,17 @@ impl Capstone {
     }
 
     /// Get error CsResult based on current errno
-    fn get_error_result<T>(&self) ->CsResult<T> {
+    fn get_error_result<T>(&self) -> CsResult<T> {
         Err(unsafe { ffi::cs_errno(self.csh) })
     }
 
     /// Set disassembling option at runtime
     /// Acts as a safe wrapper around capstone's cs_option
-    fn set_cs_option(&mut self, option_type: CsOptType, option_value: libc::size_t) -> CsResult<()> {
-        let err = unsafe {
-            ffi::cs_option(self.csh, option_type, option_value)
-        };
+    fn set_cs_option(&mut self,
+                     option_type: CsOptType,
+                     option_value: libc::size_t)
+                     -> CsResult<()> {
+        let err = unsafe { ffi::cs_option(self.csh, option_type, option_value) };
 
         if CsErr::CS_ERR_OK == err {
             self.cs_option_state.insert(option_type, option_value);
@@ -97,7 +101,7 @@ impl Capstone {
         let reg_name = unsafe {
             let _reg_name = ffi::cs_reg_name(self.csh, reg_id as libc::c_uint);
             if _reg_name == ptr::null() {
-                return None
+                return None;
             }
 
             CStr::from_ptr(_reg_name).to_string_lossy().into_owned()
@@ -111,7 +115,7 @@ impl Capstone {
         let insn_name = unsafe {
             let _insn_name = ffi::cs_insn_name(self.csh, insn_id as libc::c_uint);
             if _insn_name == ptr::null() {
-                return None
+                return None;
             }
 
             CStr::from_ptr(_insn_name).to_string_lossy().into_owned()
@@ -125,10 +129,12 @@ impl Capstone {
         let group_name = unsafe {
             let _group_name = ffi::cs_group_name(self.csh, group_id as libc::c_uint);
             if _group_name == ptr::null() {
-                return None
+                return None;
             }
 
-            CStr::from_ptr(_group_name).to_string_lossy().into_owned()
+            CStr::from_ptr(_group_name)
+                .to_string_lossy()
+                .into_owned()
         };
 
         Some(group_name)
@@ -137,8 +143,9 @@ impl Capstone {
     /// Returns whether instruction groups may be queried
     fn is_insn_group_valid(&self, insn: &Insn) -> CsResult<()> {
         /* CS_OPT_DETAIL is initialized in constructor */
-        if *self.cs_option_state.get(&CsOptType::CS_OPT_DETAIL).unwrap() ==
-            CsOptValueBool::CS_OPT_OFF as libc::size_t {
+        if *self.cs_option_state
+                .get(&CsOptType::CS_OPT_DETAIL)
+                .unwrap() == CsOptValueBool::CS_OPT_OFF as libc::size_t {
             Err(CsErr::CS_ERR_DETAIL)
         } else if insn.get_id() == 0 {
             Err(CsErr::CS_ERR_SKIPDATA)
@@ -155,9 +162,7 @@ impl Capstone {
             return Err(e);
         }
 
-        Ok(unsafe {
-            ffi::cs_insn_group(self.csh, insn as *const Insn, group_id as libc::c_uint)
-        })
+        Ok(unsafe { ffi::cs_insn_group(self.csh, insn as *const Insn, group_id as libc::c_uint) })
     }
 
 

--- a/src/capstone.rs
+++ b/src/capstone.rs
@@ -14,7 +14,7 @@ pub struct Capstone {
 pub type CsResult<T> = Result<T, CsErr>;
 
 impl Capstone {
-    /// Create a new instance of the decompiler
+    /// Create a new instance of the disassembler
     ///
     /// ```
     /// use capstone::Capstone;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,6 +23,8 @@ pub enum CsArch {
     ARCH_ALL = 0xFFFF, // All architectures - for cs_support()
 }
 
+pub const CS_SUPPORT_DIET: libc::c_int = (CsArch::ARCH_ALL as libc::c_int) + 1;
+
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Disassembler modes

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ use ffi::cs_strerror;
 use libc;
 
 #[repr(C)]
-#[derive(Clone,Copy,PartialEq,Eq,Debug)]
+#[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Architectures for the disassembler
 pub enum CsArch {
     ARCH_ARM = 0, // ARM architecture (including Thumb, Thumb-2)
@@ -22,7 +22,7 @@ pub enum CsArch {
 }
 
 #[repr(C)]
-#[derive(Clone,Copy,PartialEq,Eq,Debug)]
+#[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Disassembler modes
 pub enum CsMode {
     MODE_LITTLE_ENDIAN = 0, // little-endian mode (default mode)
@@ -44,7 +44,7 @@ pub enum CsMode {
 }
 
 #[repr(C)]
-#[derive(Clone,Copy,PartialEq,Eq,Debug)]
+#[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Error states returned by various disassembler features
 pub enum CsErr {
     CS_ERR_OK = 0, // No error: everything was fine
@@ -134,19 +134,7 @@ impl Into<libc::size_t> for CsOptValue {
 
 
 #[repr(C)]
-#[derive(Clone,Copy,PartialEq,Eq,Debug)]
-/// Common instruction operand access types
-enum CsAcType {
-    CS_GRP_INVALID = 0, // uninitialized/invalid group.
-    CS_GRP_JUMP, // all jump instructions (conditional+direct+indirect jumps)
-    CS_GRP_CALL, // all call instructions
-    CS_GRP_RET, // all return instructions
-    CS_GRP_INT, // all interrupt instructions (int+syscall)
-    CS_GRP_IRET, // all interrupt return instructions
-}
-
-#[repr(C)]
-#[derive(Clone,Copy,PartialEq,Eq,Debug)]
+#[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Common instruction groups (corresponds to cs_group_type)
 pub enum CsGroupType {
     CS_GRP_INVALID = 0, // uninitialized/invalid group.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -147,6 +147,7 @@ impl Into<libc::size_t> for CsOptValue {
 }
 
 
+enum_from_primitive! {
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Common instruction groups
@@ -159,4 +160,5 @@ pub enum CsGroupType {
     CS_GRP_RET, // all return instructions
     CS_GRP_INT, // all interrupt instructions (int+syscall)
     CS_GRP_IRET, // all interrupt return instructions
+}
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -85,15 +85,15 @@ pub enum CsOptType {
     CS_OPT_SKIPDATA, // Skip data when disassembling. Then engine is in SKIPDATA mode.
 }
 
-/// The cs_opt_value C enum is partitioned into CsOptValueBool and CsOptValueSyntax Rust enums
-/// because Rust enum variants must have unique discriminant values
+// The cs_opt_value C enum is partitioned into CsOptValueBool and CsOptValueSyntax Rust enums
+// because Rust enum variants must have unique discriminant values
 
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Boolean runtime option values corresponding to CsOptType
 pub enum CsOptValueBool {
-	CS_OPT_OFF = 0, // Turn OFF an option - default option of CS_OPT_DETAIL, CS_OPT_SKIPDATA.
-	CS_OPT_ON = 3, // Turn ON an option (CS_OPT_DETAIL, CS_OPT_SKIPDATA).
+    CS_OPT_OFF = 0, // Turn OFF an option - default option of CS_OPT_DETAIL, CS_OPT_SKIPDATA.
+    CS_OPT_ON = 3, // Turn ON an option (CS_OPT_DETAIL, CS_OPT_SKIPDATA).
 }
 
 impl From<bool> for CsOptValueBool {
@@ -110,10 +110,10 @@ impl From<bool> for CsOptValueBool {
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Runtime option values corresponding to CsOptType syntax options
 pub enum CsOptValueSyntax {
-	CS_OPT_SYNTAX_DEFAULT = 0, // Default asm syntax (CS_OPT_SYNTAX).
-	CS_OPT_SYNTAX_INTEL, // X86 Intel asm syntax - default on X86 (CS_OPT_SYNTAX).
-	CS_OPT_SYNTAX_ATT, // X86 ATT asm syntax (CS_OPT_SYNTAX).
-	CS_OPT_SYNTAX_NOREGNAME, // Prints register name with only number (CS_OPT_SYNTAX)
+    CS_OPT_SYNTAX_DEFAULT = 0, // Default asm syntax (CS_OPT_SYNTAX).
+    CS_OPT_SYNTAX_INTEL, // X86 Intel asm syntax - default on X86 (CS_OPT_SYNTAX).
+    CS_OPT_SYNTAX_ATT, // X86 ATT asm syntax (CS_OPT_SYNTAX).
+    CS_OPT_SYNTAX_NOREGNAME, // Prints register name with only number (CS_OPT_SYNTAX)
 }
 
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,6 +7,8 @@ use libc;
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Architectures for the disassembler
+///
+/// Corresponds to the Capstone type `cs_arch`.
 pub enum CsArch {
     ARCH_ARM = 0, // ARM architecture (including Thumb, Thumb-2)
     ARCH_ARM64, // ARM-64, also called AArch64
@@ -24,6 +26,8 @@ pub enum CsArch {
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Disassembler modes
+///
+/// Corresponds to the Capstone type `cs_mode`.
 pub enum CsMode {
     MODE_LITTLE_ENDIAN = 0, // little-endian mode (default mode)
     // MODE_ARM = 0,    // 32-bit ARM
@@ -46,6 +50,8 @@ pub enum CsMode {
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Error states returned by various disassembler features
+///
+/// Corresponds to the Capstone type `cs_err`.
 pub enum CsErr {
     CS_ERR_OK = 0, // No error: everything was fine
     CS_ERR_MEM, // Out-Of-Memory error: cs_open(), cs_disasm(), cs_disasm_iter()
@@ -76,6 +82,8 @@ impl fmt::Display for CsErr {
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Runtime option for the disassembled engine
+///
+/// Corresponds to the Capstone type `cs_opt_type`.
 pub enum CsOptType {
     CS_OPT_INVALID = 0, // No option specified
     CS_OPT_SYNTAX, // Assembly output syntax
@@ -91,6 +99,8 @@ pub enum CsOptType {
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
 /// Boolean runtime option values corresponding to CsOptType
+///
+/// Corresponds to a subset of the Capstone type `cs_opt_value`.
 pub enum CsOptValueBool {
     CS_OPT_OFF = 0, // Turn OFF an option - default option of CS_OPT_DETAIL, CS_OPT_SKIPDATA.
     CS_OPT_ON = 3, // Turn ON an option (CS_OPT_DETAIL, CS_OPT_SKIPDATA).
@@ -108,7 +118,9 @@ impl From<bool> for CsOptValueBool {
 
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
-/// Runtime option values corresponding to CsOptType syntax options
+/// Runtime option values corresponding to `CsOptType::CS_OPT_SYNTAX`
+///
+/// Corresponds to a subset of the Capstone type `cs_opt_value`.
 pub enum CsOptValueSyntax {
     CS_OPT_SYNTAX_DEFAULT = 0, // Default asm syntax (CS_OPT_SYNTAX).
     CS_OPT_SYNTAX_INTEL, // X86 Intel asm syntax - default on X86 (CS_OPT_SYNTAX).
@@ -117,7 +129,9 @@ pub enum CsOptValueSyntax {
 }
 
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
-/// Runtime option values corresponding to all possible cs_opt_value CsOptType
+/// Runtime option values corresponding to all possible `CsOptType`
+///
+/// Corresponds to the Capstone type `cs_opt_value`.
 pub enum CsOptValue {
     Bool(CsOptValueBool),
     Syntax(CsOptValueSyntax),
@@ -135,7 +149,9 @@ impl Into<libc::size_t> for CsOptValue {
 
 #[repr(C)]
 #[derive(Clone,Copy,PartialEq,Eq,Debug,Hash)]
-/// Common instruction groups (corresponds to cs_group_type)
+/// Common instruction groups
+///
+/// Corresponds to Capstone's `cs_group_type`.
 pub enum CsGroupType {
     CS_GRP_INVALID = 0, // uninitialized/invalid group.
     CS_GRP_JUMP, // all jump instructions (conditional+direct+indirect jumps)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -22,6 +22,8 @@ extern "C" {
     pub fn cs_insn_name(handle: csh, insn_id: libc::c_uint) -> *const libc::c_char;
     pub fn cs_group_name(handle: csh, group_id: libc::c_uint) -> *const libc::c_char;
     pub fn cs_insn_group(handle: csh, cs_insn: *const Insn, group_id: libc::c_uint) -> bool;
+    pub fn cs_reg_read(handle: csh, cs_insn: *const Insn, reg_id: libc::c_uint) -> bool;
+    pub fn cs_reg_write(handle: csh, cs_insn: *const Insn, reg_id: libc::c_uint) -> bool;
     pub fn cs_option(handle: csh, option_type: CsOptType, value: libc::size_t) -> CsErr;
     pub fn cs_errno(handle: csh) -> CsErr;
     pub fn cs_strerror(err: CsErr) -> *const libc::c_char;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,12 +1,13 @@
 use libc;
 use instruction::Insn;
-use constants::{CsArch, CsMode, CsErr};
+use constants::{CsArch, CsMode, CsErr, CsOptType};
 use csh;
 
 #[allow(dead_code)]
 #[link(name = "capstone")]
 extern "C" {
     pub fn cs_version(major: *mut libc::c_int, minor: *mut libc::c_int) -> libc::c_uint;
+    pub fn cs_support(query: libc::c_int) -> bool;
     pub fn cs_open(arch: CsArch, mode: CsMode, handle: *mut csh) -> CsErr;
     pub fn cs_close(handle: *mut csh) -> CsErr;
     pub fn cs_disasm(handle: csh,
@@ -19,6 +20,9 @@ extern "C" {
     pub fn cs_free(insn: *const Insn, count: libc::size_t);
     pub fn cs_reg_name(handle: csh, reg_id: libc::c_uint) -> *const libc::c_char;
     pub fn cs_insn_name(handle: csh, insn_id: libc::c_uint) -> *const libc::c_char;
+    pub fn cs_group_name(handle: csh, group_id: libc::c_uint) -> *const libc::c_char;
+    pub fn cs_insn_group(handle: csh, cs_insn: *const Insn, group_id: libc::c_uint) -> bool;
+    pub fn cs_option(handle: csh, option_type: CsOptType, value: libc::size_t) -> CsErr;
     pub fn cs_errno(handle: csh) -> CsErr;
     pub fn cs_strerror(err: CsErr) -> *const libc::c_char;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,7 @@ use csh;
 #[allow(dead_code)]
 #[link(name = "capstone")]
 extern "C" {
+    pub fn cs_version(major: *mut libc::c_int, minor: *mut libc::c_int) -> libc::c_uint;
     pub fn cs_open(arch: CsArch, mode: CsMode, handle: *mut csh) -> CsErr;
     pub fn cs_close(handle: *mut csh) -> CsErr;
     pub fn cs_disasm(handle: csh,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -131,7 +131,18 @@ pub struct CsDetail {
 }
 
 impl CsDetail {
-    pub fn get_groups(&self) -> &[u8] {
+    /// Return ids of implicit read registers
+    pub fn get_regs_read_ids(&self) -> &[u8] {
+        &self.regs_read[..self.regs_read_count as usize]
+    }
+
+    /// Return ids of implicit write registers
+    pub fn get_regs_write_ids(&self) -> &[u8] {
+        &self.regs_write[..self.regs_write_count as usize]
+    }
+
+    /// Return ids of instruction groups to which instructions belong
+    pub fn get_group_ids(&self) -> &[u8] {
         &self.groups[..self.groups_count as usize]
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -120,7 +120,9 @@ impl Display for Insn {
 }
 
 #[repr(C)]
-/// Represents details for instruction, available if disassembled with details
+/// Represents details for instruction
+///
+/// Only available if disassembled with details.
 pub struct CsDetail {
     regs_read: [u8; 12usize], // list of implicit registers read by this insn
     regs_read_count: u8, // number of implicit registers read by this insn

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -70,7 +70,7 @@ pub struct Insn {
     bytes: [u8; 16usize],
     mnemonic: [::libc::c_char; 32usize],
     op_str: [::libc::c_char; 160usize],
-    detail: *mut libc::c_void, // Opaque cs_detail
+    pub detail: *mut CsDetail, // Opaque cs_detail
 }
 
 impl Insn {
@@ -84,6 +84,16 @@ impl Insn {
     pub fn op_str(&self) -> Option<&str> {
         let cstr = unsafe { CStr::from_ptr(self.op_str.as_ptr()) };
         str::from_utf8(cstr.to_bytes()).ok()
+    }
+
+    /// Access instruction id
+    pub fn get_id(&self) -> libc::c_uint {
+        self.id
+    }
+
+    /// Access instruction bytes
+    pub fn get_bytes(&self) -> &[u8] {
+        &self.bytes[0..(self.size as usize)]
     }
 }
 
@@ -109,5 +119,22 @@ impl Display for Insn {
             }
         }
         Ok(())
+    }
+}
+
+#[repr(C)]
+/// Represents details for instruction, available if disassembled with details
+pub struct CsDetail {
+    regs_read: [u8; 12usize], // list of implicit registers read by this insn
+    regs_read_count: u8, // number of implicit registers read by this insn
+    regs_write: [u8; 20usize], // list of implicit registers modified by this insn
+    regs_write_count: u8, // number of implicit registers modified by this insn
+    groups: [u8; 8usize], // list of group this instruction belong to
+    groups_count: u8, // number of groups this insn belongs to
+}
+
+impl CsDetail {
+    pub fn get_groups(&self) -> &[u8] {
+        &self.groups[..self.groups_count as usize]
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -64,12 +64,45 @@ impl<'a> Iterator for InstructionIterator<'a> {
 #[repr(C)]
 /// A logical instruction disassembled by capstone
 pub struct Insn {
+    /// Instruction ID (numeric ID for the instruction mnemonic)
+    ///
+    /// This information is available when Detail is disabled.
+    /// NOTE: in Skipdata mode, "data" instruction has 0 for this id field.
     id: ::libc::c_uint,
+
+    /// Address of this instruction
+    ///
+    /// This information is available when Detail is disabled.
     pub address: u64,
+
+    /// Size of this instruction
+    ///
+    /// This information is available when Detail is disabled.
     pub size: u16,
+
+    /// Machine bytes of this instruction, with number of bytes indicated by @size above.
+    ///
+    /// This information is available when Detail is disabled.
     bytes: [u8; 16usize],
+
+    /// Ascii text of instruction mnemonic
+    ///
+    /// This information is available when Detail is disabled.
     mnemonic: [::libc::c_char; 32usize],
+
+    /// Ascii text of instruction operands
+    ///
+    /// This information is available when Detail is disabled.
     op_str: [::libc::c_char; 160usize],
+
+    /// Pointer to `CsDetail`
+    ///
+    /// NOTE 1: detail pointer is only valid when both requirements below are met:
+    ///     1. Detail is enabled
+    ///     2. Engine is not in Skipdata mode
+    ///
+    /// NOTE 2: when in Skipdata mode, or when detail mode is OFF, even if this pointer is not
+    /// NULL, its content is still irrelevant.
     detail: *mut CsDetail,
 }
 
@@ -134,12 +167,23 @@ impl Display for Insn {
 ///
 /// Only available if disassembled with details.
 pub struct CsDetail {
-    regs_read: [u8; 12usize], // list of implicit registers read by this insn
-    regs_read_count: u8, // number of implicit registers read by this insn
-    regs_write: [u8; 20usize], // list of implicit registers modified by this insn
-    regs_write_count: u8, // number of implicit registers modified by this insn
-    groups: [u8; 8usize], // list of group this instruction belong to
-    groups_count: u8, // number of groups this insn belongs to
+    /// Ids of implicit registers read by this instruction
+    regs_read: [u8; 12usize],
+
+    /// Number of implicit registers read by this instruction
+    regs_read_count: u8,
+
+    /// Ids of implicit registers modified by this instruction
+    regs_write: [u8; 20usize],
+
+    /// Number of implicit registers modified by this instruction
+    regs_write_count: u8,
+
+    /// Ids of groups this instruction belongs to
+    groups: [u8; 8usize],
+
+    /// Number of groups this instruction belongs to
+    groups_count: u8,
 }
 
 impl CsDetail {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -13,10 +13,7 @@ pub struct Instructions {
 
 impl Instructions {
     pub unsafe fn from_raw_parts(ptr: *const Insn, len: isize) -> Instructions {
-        Instructions {
-            ptr: ptr,
-            len: len,
-        }
+        Instructions { ptr: ptr, len: len }
     }
 
     pub fn len(&self) -> isize {
@@ -100,11 +97,11 @@ impl Insn {
 impl Debug for Insn {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
         fmt.debug_struct("Insn")
-           .field("address", &self.address)
-           .field("size", &self.size)
-           .field("mnemonic", &self.mnemonic())
-           .field("op_str", &self.op_str())
-           .finish()
+            .field("address", &self.address)
+            .field("size", &self.size)
+            .field("mnemonic", &self.mnemonic())
+            .field("op_str", &self.op_str())
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,8 @@ mod test {
 
     #[test]
     fn test_capstone_version() {
-        let (major, minor) = capstone::capstone_lib_version();
+        let (major, minor) = capstone::lib_version();
+        println!("Capstone lib version: ({}, {})", major, minor);
         assert!(major > 0 && major < 100, "Invalid major version {}", major);
         assert!(minor < 500, "Invalid minor version {}", minor);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ mod test {
 
     #[test]
     fn test_capstone_version() {
-        let (major, minor) = capstone::lib_version();
+        let (major, minor) = Capstone::lib_version();
         println!("Capstone lib version: ({}, {})", major, minor);
         assert!(major > 0 && major < 100, "Invalid major version {}", major);
         assert!(minor < 500, "Invalid minor version {}", minor);
@@ -293,13 +293,13 @@ mod test {
 
         println!("Supported architectures");
         for arch in architectures {
-            let supports_arch = capstone::supports_arch(arch);
+            let supports_arch = Capstone::supports_arch(arch);
             println!("  {:?}: {}", arch, if supports_arch { "yes" } else { "no" });
         }
     }
 
     #[test]
     fn test_capstone_is_diet() {
-        println!("Capstone is diet: {}", capstone::is_diet());
+        println!("Capstone is diet: {}", Capstone::is_diet());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,10 @@ mod test {
 
                         assert_eq!(is[0].get_bytes(), b"\x55");
                         assert_eq!(is[1].get_bytes(), b"\x48\x8b\x05\xb8\x13\x00\x00");
-                    },
-                    Err(err) => {
-                        assert!(false, "Couldn't disasm instructions: {}", err)
                     }
+                    Err(err) => assert!(false, "Couldn't disasm instructions: {}", err),
                 }
-            },
+            }
             Err(e) => {
                 assert!(false, "Couldn't create a cs engine: {}", e);
             }
@@ -76,17 +74,17 @@ mod test {
                 let reg_id = 6000;
                 match cs.reg_name(reg_id) {
                     Some(_) => assert!(false, "invalid register worked"),
-                    None => {},
+                    None => {}
                 }
 
                 let insn_id = 6000;
                 match cs.insn_name(insn_id) {
                     Some(_) => assert!(false, "invalid instruction worked"),
-                    None => {},
+                    None => {}
                 }
 
                 assert_eq!(cs.group_name(6000), None);
-            },
+            }
             Err(e) => {
                 assert!(false, "Couldn't create a cs engine: {}", e);
             }
@@ -96,47 +94,53 @@ mod test {
     #[test]
     fn test_detail_false_fail() {
         let mut cs = capstone::Capstone::new(constants::CsArch::ARCH_X86,
-                                             constants::CsMode::MODE_64).unwrap();
+                                             constants::CsMode::MODE_64)
+                .unwrap();
         cs.set_detail(false).unwrap();
         let insns: Vec<_> = cs.disasm(CODE, 0x1000, 0).unwrap().iter().collect();
-        assert_eq!(cs.insn_belongs_to_group(&insns[0], 0), Err(CsErr::CS_ERR_DETAIL));
-        assert_eq!(cs.insn_belongs_to_group(&insns[1], 0), Err(CsErr::CS_ERR_DETAIL));
+        assert_eq!(cs.insn_belongs_to_group(&insns[0], 0),
+                   Err(CsErr::CS_ERR_DETAIL));
+        assert_eq!(cs.insn_belongs_to_group(&insns[1], 0),
+                   Err(CsErr::CS_ERR_DETAIL));
     }
 
     #[test]
     fn test_detail_true() {
         let mut cs = capstone::Capstone::new(constants::CsArch::ARCH_X86,
-                                             constants::CsMode::MODE_64).unwrap();
+                                             constants::CsMode::MODE_64)
+                .unwrap();
         cs.set_detail(true).unwrap();
         let insns: Vec<_> = cs.disasm(CODE, 0x1000, 0).unwrap().iter().collect();
-        let insn_group_ids = [
-            CsGroupType::CS_GRP_JUMP, CsGroupType::CS_GRP_CALL, CsGroupType::CS_GRP_RET,
-            CsGroupType::CS_GRP_INT, CsGroupType::CS_GRP_IRET
-        ];
-        for insn_idx in 0..1+1 {
+        let insn_group_ids = [CsGroupType::CS_GRP_JUMP,
+                              CsGroupType::CS_GRP_CALL,
+                              CsGroupType::CS_GRP_RET,
+                              CsGroupType::CS_GRP_INT,
+                              CsGroupType::CS_GRP_IRET];
+        for insn_idx in 0..1 + 1 {
             for insn_group_id in &insn_group_ids {
-                assert_eq!(
-                    cs.insn_belongs_to_group(&insns[insn_idx], *insn_group_id as u64),
-                    Ok(false));
+                assert_eq!(cs.insn_belongs_to_group(&insns[insn_idx], *insn_group_id as u64),
+                           Ok(false));
             }
         }
     }
 
     /// Assert instruction belongs or does not belong to groups
     fn test_x86_instruction_groups_helper(mnemonic_name: &str,
-                                   bytes: &[u8],
-                                   belong_groups: &[CsGroupType],
-                                   not_belong_groups: &[CsGroupType]) {
+                                          bytes: &[u8],
+                                          belong_groups: &[CsGroupType],
+                                          not_belong_groups: &[CsGroupType]) {
         let mut cs = capstone::Capstone::new(constants::CsArch::ARCH_X86,
                                              constants::CsMode::MODE_64)
-                                            .expect("Failed to create capstone handle");
+                .expect("Failed to create capstone handle");
 
         // Details required to get groups information
         cs.set_detail(true).unwrap();
 
         // Disassemble instructions
-        let insns: Vec<_> = cs.disasm(bytes, 0x1000, 0).expect("Failed to disassemble")
-            .iter().collect();
+        let insns: Vec<_> = cs.disasm(bytes, 0x1000, 0)
+            .expect("Failed to disassemble")
+            .iter()
+            .collect();
 
         // Check number of instructions
         assert_eq!(insns.len(), 1, "Expected exactly 1 instruction");
@@ -145,19 +149,25 @@ mod test {
 
         // Check mnemonic
         assert_eq!(mnemonic_name,
-                   cs.insn_name(insn.get_id() as u64).expect("Failed to get instruction name"));
+                   cs.insn_name(insn.get_id() as u64)
+                       .expect("Failed to get instruction name"));
 
         // Assert instruction belongs to belong_groups
         for belong_group in belong_groups {
             assert_eq!(Ok(true),
                        cs.insn_belongs_to_group(&insn, *belong_group as u64),
-                       "{:?} does NOT BELONG to group {:?}", insn, *belong_group);
+                       "{:?} does NOT BELONG to group {:?}",
+                       insn,
+                       *belong_group);
         }
 
         // Assert instruction does not belong to not_belong_groups
         for not_belong_group in not_belong_groups {
-            assert_eq!(Ok(false), cs.insn_belongs_to_group(&insn, *not_belong_group as u64),
-                       "{:?} BELONGS to group {:?}", insn, *not_belong_group);
+            assert_eq!(Ok(false),
+                       cs.insn_belongs_to_group(&insn, *not_belong_group as u64),
+                       "{:?} BELONGS to group {:?}",
+                       insn,
+                       *not_belong_group);
         }
     }
 
@@ -171,12 +181,24 @@ mod test {
 
         test_x86_instruction_groups_helper("nop", b"\x90", &[], &[jump, call, ret, int, iret]);
         test_x86_instruction_groups_helper("je", b"\x74\x05", &[jump], &[call, ret, int, iret]);
-        test_x86_instruction_groups_helper("call", b"\xe8\x28\x07\x00\x00", &[call], &[jump, ret, int, iret]);
+        test_x86_instruction_groups_helper("call",
+                                           b"\xe8\x28\x07\x00\x00",
+                                           &[call],
+                                           &[jump, ret, int, iret]);
         test_x86_instruction_groups_helper("ret", b"\xc3", &[ret], &[jump, call, int, iret]);
-        test_x86_instruction_groups_helper("syscall", b"\x0f\x05", &[int], &[jump, call, ret, iret]);
+        test_x86_instruction_groups_helper("syscall",
+                                           b"\x0f\x05",
+                                           &[int],
+                                           &[jump, call, ret, iret]);
         test_x86_instruction_groups_helper("iretd", b"\xcf", &[iret], &[jump, call, ret, int]);
-        test_x86_instruction_groups_helper("sub", b"\x48\x83\xec\x08", &[], &[jump, call, ret, int, iret]);
-        test_x86_instruction_groups_helper("test", b"\x48\x85\xc0", &[], &[jump, call, ret, int, iret]);
+        test_x86_instruction_groups_helper("sub",
+                                           b"\x48\x83\xec\x08",
+                                           &[],
+                                           &[jump, call, ret, int, iret]);
+        test_x86_instruction_groups_helper("test",
+                                           b"\x48\x85\xc0",
+                                           &[],
+                                           &[jump, call, ret, int, iret]);
     }
 
     /// Assert instruction belongs or does not belong to groups
@@ -185,14 +207,16 @@ mod test {
                                              expected_groups: &[CsGroupType]) {
         let mut cs = capstone::Capstone::new(constants::CsArch::ARCH_X86,
                                              constants::CsMode::MODE_64)
-                                            .expect("Failed to create capstone handle");
+                .expect("Failed to create capstone handle");
 
         // Details required to get groups information
         cs.set_detail(true).unwrap();
 
         // Disassemble instructions
-        let insns: Vec<_> = cs.disasm(bytes, 0x1000, 0).expect("Failed to disassemble")
-            .iter().collect();
+        let insns: Vec<_> = cs.disasm(bytes, 0x1000, 0)
+            .expect("Failed to disassemble")
+            .iter()
+            .collect();
 
         // Check number of instructions
         assert_eq!(insns.len(), 1, "Expected exactly 1 instruction");
@@ -201,17 +225,20 @@ mod test {
 
         // Check mnemonic
         assert_eq!(mnemonic_name,
-                   cs.insn_name(insn.get_id() as u64).expect("Failed to get instruction name"));
+                   cs.insn_name(insn.get_id() as u64)
+                       .expect("Failed to get instruction name"));
 
         // Assert expected instruction groups is a subset of computed groups
         let instruction_groups: HashSet<u8> = cs.get_insn_group_ids(&insn)
-                                                .expect("failed to get instruction groups")
-                                                .iter().map(|&x| x).collect();
+            .expect("failed to get instruction groups")
+            .iter()
+            .map(|&x| x)
+            .collect();
         let expected_groups: HashSet<u8> = expected_groups.iter().map(|&x| x as u8).collect();
         assert!(expected_groups.is_subset(&instruction_groups),
-                   "Expected groups {:?} does NOT match computed insn groups {:?}",
-                   expected_groups, instruction_groups
-                   );
+                "Expected groups {:?} does NOT match computed insn groups {:?}",
+                expected_groups,
+                instruction_groups);
     }
 
     #[test]
@@ -235,8 +262,8 @@ mod test {
     #[test]
     fn test_invalid_mode() {
         match capstone::Capstone::new(constants::CsArch::ARCH_ALL, constants::CsMode::MODE_64) {
-            Ok(_) => { assert!(false, "Invalid open worked") },
-            Err(err) => { assert!(err == constants::CsErr::CS_ERR_ARCH) },
+            Ok(_) => assert!(false, "Invalid open worked"),
+            Err(err) => assert!(err == constants::CsErr::CS_ERR_ARCH),
         }
     }
 
@@ -250,10 +277,15 @@ mod test {
 
     #[test]
     fn test_capstone_supports_arch() {
-        let architectures = vec![
-            CsArch::ARCH_ARM, CsArch::ARCH_ARM64, CsArch::ARCH_MIPS, CsArch::ARCH_X86,
-            CsArch::ARCH_PPC, CsArch::ARCH_SPARC, CsArch::ARCH_SYSZ, CsArch::ARCH_XCORE,
-            CsArch::CS_ARCH_M68K];
+        let architectures = vec![CsArch::ARCH_ARM,
+                                 CsArch::ARCH_ARM64,
+                                 CsArch::ARCH_MIPS,
+                                 CsArch::ARCH_X86,
+                                 CsArch::ARCH_PPC,
+                                 CsArch::ARCH_SPARC,
+                                 CsArch::ARCH_SYSZ,
+                                 CsArch::ARCH_XCORE,
+                                 CsArch::CS_ARCH_M68K];
 
         println!("Supported architectures");
         for arch in architectures {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod test {
     }
 
     /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
-    /// and get_insn_group_ids
+    /// and insn_group_ids
     fn test_x86_instruction_detail_helper(mnemonic_name: &str,
                                           bytes: &[u8],
                                           expected_groups: &[CsGroupType]) {
@@ -182,7 +182,7 @@ mod test {
                        .expect("Failed to get instruction name"));
 
         // Assert expected instruction groups is a subset of computed groups through ids
-        let instruction_group_ids: HashSet<u8> = cs.get_insn_group_ids(&insn)
+        let instruction_group_ids: HashSet<u8> = cs.insn_group_ids(&insn)
             .expect("failed to get instruction groups")
             .iter()
             .map(|&x| x)
@@ -194,7 +194,7 @@ mod test {
                 instruction_group_ids);
 
         // Assert expected instruction groups is a subset of computed groups through enum
-        let instruction_groups_set: HashSet<CsGroupType> = cs.get_insn_groups(&insn)
+        let instruction_groups_set: HashSet<CsGroupType> = cs.insn_groups(&insn)
             .expect("failed to get instruction groups")
             .iter()
             .map(|&x| x)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,28 @@
+//! This crate is a wrapper around the
+//! [Capstone disassembly library](http://www.capstone-engine.org/),
+//! a "lightweight multi-platform, multi-architecture disassembly framework."
+//!
+//! The `Capstone` struct is the main interface to the library.
+//!
+//! ```
+//! use capstone;
+//!
+//! let cs = capstone::Capstone::new(capstone::CsArch::ARCH_X86,
+//!                                  capstone::CsMode::MODE_64)
+//!     .unwrap();
+//! let insns = cs.disasm(b"\x55\x48\x8b\x05\xb8\x13\x00\x00", 0x1000, 0)
+//!     .unwrap();
+//!
+//! for insn in insns.iter() {
+//!     println!("{addr:x} {bytes:?} {mnemonic} {ops}",
+//!              addr = insn.address,
+//!              bytes = insn.get_bytes(),
+//!              mnemonic = insn.mnemonic().unwrap(),
+//!              ops = insn.op_str().unwrap());
+//! }
+//! ```
+//!
+
 extern crate libc;
 
 pub mod instruction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,9 @@ mod test {
 
     /// Assert instruction belongs or does not belong to groups, testing both insn_belongs_to_group
     /// and get_insn_group_ids
-    fn test_x86_instruction_group_ids_helper(mnemonic_name: &str,
-                                             bytes: &[u8],
-                                             expected_groups: &[CsGroupType]) {
+    fn test_x86_instruction_detail_helper(mnemonic_name: &str,
+                                          bytes: &[u8],
+                                          expected_groups: &[CsGroupType]) {
         let mut cs = capstone::Capstone::new(constants::CsArch::ARCH_X86,
                                              constants::CsMode::MODE_64)
                 .expect("Failed to create capstone handle");
@@ -179,22 +179,26 @@ mod test {
         let not_belong_groups = instruction_types.difference(&expected_groups_set);
 
         // Assert instruction belongs to belong_groups
-        for belong_group in expected_groups {
+        for &belong_group in expected_groups {
             assert_eq!(Ok(true),
-                       cs.insn_belongs_to_group(&insn, *belong_group as u64),
+                       cs.insn_belongs_to_group(&insn, belong_group as u64),
                        "{:?} does NOT BELONG to group {:?}, but the instruction SHOULD",
                        insn,
-                       *belong_group);
+                       belong_group);
         }
 
         // Assert instruction does not belong to not_belong_groups
-        for not_belong_group in not_belong_groups {
+        for &not_belong_group in not_belong_groups {
             assert_eq!(Ok(false),
-                       cs.insn_belongs_to_group(&insn, *not_belong_group as u64),
+                       cs.insn_belongs_to_group(&insn, not_belong_group as u64),
                        "{:?} BELONGS to group {:?}, but the instruction SHOULD NOT",
                        insn,
-                       *not_belong_group);
+                       not_belong_group);
         }
+
+        // @todo: check read_registers
+
+        // @todo: check write_registers
     }
 
     #[test]
@@ -205,14 +209,16 @@ mod test {
         let int = CsGroupType::CS_GRP_INT;
         let iret = CsGroupType::CS_GRP_IRET;
 
-        test_x86_instruction_group_ids_helper("nop", b"\x90", &[]);
-        test_x86_instruction_group_ids_helper("je", b"\x74\x05", &[jump]);
-        test_x86_instruction_group_ids_helper("call", b"\xe8\x28\x07\x00\x00", &[call]);
-        test_x86_instruction_group_ids_helper("ret", b"\xc3", &[ret]);
-        test_x86_instruction_group_ids_helper("syscall", b"\x0f\x05", &[int]);
-        test_x86_instruction_group_ids_helper("iretd", b"\xcf", &[iret]);
-        test_x86_instruction_group_ids_helper("sub", b"\x48\x83\xec\x08", &[]);
-        test_x86_instruction_group_ids_helper("test", b"\x48\x85\xc0", &[]);
+        test_x86_instruction_detail_helper("nop", b"\x90", &[]);
+        test_x86_instruction_detail_helper("je", b"\x74\x05", &[jump]);
+        test_x86_instruction_detail_helper("call", b"\xe8\x28\x07\x00\x00", &[call]);
+        test_x86_instruction_detail_helper("ret", b"\xc3", &[ret]);
+        test_x86_instruction_detail_helper("syscall", b"\x0f\x05", &[int]);
+        test_x86_instruction_detail_helper("iretd", b"\xcf", &[iret]);
+        test_x86_instruction_detail_helper("sub", b"\x48\x83\xec\x08", &[]);
+        test_x86_instruction_detail_helper("test", b"\x48\x85\xc0", &[]);
+        test_x86_instruction_detail_helper("mov", b"\x48\x8b\x05\x95\x4a\x4d\x00", &[]);
+        test_x86_instruction_detail_helper("mov", b"\xb9\x04\x02\x00\x00", &[]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use capstone::Capstone;
 /// It should not be exported, rust's new visibility rules make tackling this not immediately
 /// obvious
 #[allow(non_camel_case_types)]
-type csh = libc::c_ulong;
+type csh = libc::size_t;
 
 #[cfg(test)]
 mod test {
@@ -90,5 +90,12 @@ mod test {
             Ok(_) => { assert!(false, "Invalid open worked") },
             Err(err) => { assert!(err == constants::CsErr::CS_ERR_ARCH) },
         }
+    }
+
+    #[test]
+    fn test_capstone_version() {
+        let (major, minor) = capstone::capstone_lib_version();
+        assert!(major > 0 && major < 100, "Invalid major version {}", major);
+        assert!(minor < 500, "Invalid minor version {}", minor);
     }
 }


### PR DESCRIPTION
This is a first take at resolving #7. I did not break the interface but expose some of the functionality in the cs_detail.

I did not add any functionality that requires architecture-specific header information (such as instruction or register ids) because the architecture-specific headers are so large and need to be automatically parsed first.

